### PR TITLE
#4: remaining composition objects

### DIFF
--- a/src/Support/LayoutBlocks/Composition/ConfirmationDialogObject.php
+++ b/src/Support/LayoutBlocks/Composition/ConfirmationDialogObject.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\CompositionObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
+
+class ConfirmationDialogObject extends CompositionObject
+{
+    use MergesArrays;
+
+    protected TextObject $title;
+
+    protected TextObject $text;
+
+    protected TextObject $confirmText;
+
+    protected TextObject $denyText;
+
+    protected ?string $confirmButtonStyle = null;
+
+    public function __construct(TextObject $title, TextObject $text, TextObject $confirmText, TextObject $denyText)
+    {
+        $this->title = $title;
+        $this->text = $text;
+        $this->confirmText = $confirmText;
+        $this->denyText = $denyText;
+    }
+
+    public function confirmButtonPrimary(): self
+    {
+        $this->confirmButtonStyle = 'primary';
+        return $this;
+    }
+
+    public function confirmButtonDanger(): self
+    {
+        $this->confirmButtonStyle = 'danger';
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->toMergedArray([
+            'title' => $this->title->toArray(),
+            'text' => $this->text->toArray(),
+            'confirm' => $this->confirmText->toArray(),
+            'deny' => $this->denyText->toArray(),
+            'style' => $this->confirmButtonStyle,
+        ]);
+    }
+}

--- a/src/Support/LayoutBlocks/Composition/DispatchActionConfigurationObject.php
+++ b/src/Support/LayoutBlocks/Composition/DispatchActionConfigurationObject.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\CompositionObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
+
+class DispatchActionConfigurationObject extends CompositionObject
+{
+    use MergesArrays;
+
+    /**
+     * @var string[]
+     */
+    protected array $triggerActionsOn = [];
+
+    public function onEnterPressed(): self
+    {
+        $this->triggerActionsOn[] = 'on_enter_pressed';
+        return $this;
+    }
+
+    public function onCharacterEntered(): self
+    {
+        $this->triggerActionsOn[] = 'on_character_entered';
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->toMergedArray([
+            'trigger_actions_on' => !empty($this->triggerActionsOn) ? $this->triggerActionsOn : null,
+        ]);
+    }
+}

--- a/src/Support/LayoutBlocks/Composition/FilterObject.php
+++ b/src/Support/LayoutBlocks/Composition/FilterObject.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\CompositionObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
+
+class FilterObject extends CompositionObject
+{
+    use MergesArrays;
+
+    /**
+     * @var string[]|null
+     */
+    protected ?array $include = null;
+
+    protected ?bool $excludeExternalSharedChannels = null;
+
+    protected ?bool $excludeBotUsers = null;
+
+    public function includeConversationTypes(array $include = []): self
+    {
+        $this->include = $include;
+        return $this;
+    }
+
+    public function excludeExternalSharedChannels(bool $exclude = true): self
+    {
+        $this->excludeExternalSharedChannels = $exclude;
+        return $this;
+    }
+
+    public function excludeBotUsers(bool $exclude = true): self
+    {
+        $this->excludeBotUsers = $exclude;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->toMergedArray([
+            'include' => $this->include,
+            'exclude_external_shared_channels' => $this->excludeExternalSharedChannels,
+            'exclude_bot_users' => $this->excludeBotUsers,
+        ]);
+    }
+}

--- a/src/Support/LayoutBlocks/Composition/OptionGroupObject.php
+++ b/src/Support/LayoutBlocks/Composition/OptionGroupObject.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\CompositionObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
+
+class OptionGroupObject extends CompositionObject
+{
+    use MergesArrays;
+
+    protected TextObject $label;
+
+    /**
+     * @var OptionObject[]
+     */
+    protected array $options;
+
+    /**
+     * @param TextObject $label
+     * @param OptionObject[] $options
+     */
+    public function __construct(TextObject $label, array $options)
+    {
+        $this->label = $label;
+        $this->options = $options;
+    }
+
+    public function toArray(): array
+    {
+        return $this->toMergedArray([
+            'label' => $this->label->toArray(),
+            'options' => array_map(function (OptionObject $option): array {
+                return $option->toArray();
+            }, $this->options),
+        ]);
+    }
+}

--- a/src/Support/LayoutBlocks/Elements/ButtonElement.php
+++ b/src/Support/LayoutBlocks/Elements/ButtonElement.php
@@ -6,12 +6,13 @@ namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\HasActionId;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 
 class ButtonElement extends Element
 {
-    use HasActionId, MergesArrays;
+    use HasActionId, MergesArrays, WithConfirmationDialog;
 
     protected TextObject $text;
 
@@ -69,13 +70,13 @@ class ButtonElement extends Element
 
     public function toArray(): array
     {
-        return $this->toMergedArray([
+        return $this->toMergedArray($this->mergeConfirmationDialog([
             'text' => $this->text->toArray(),
             'action_id' => $this->actionId,
             'style' => $this->style,
             'url' => $this->url,
             'value' => $this->value,
             'accessibility_label' => $this->accessibilityLabel,
-        ]);
+        ]));
     }
 }

--- a/src/Support/LayoutBlocks/Elements/CheckboxesElement.php
+++ b/src/Support/LayoutBlocks/Elements/CheckboxesElement.php
@@ -6,12 +6,13 @@ namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Composition\WithFocusOnLoad;
 
 class CheckboxesElement extends Element
 {
-    use MergesArrays, WithFocusOnLoad;
+    use MergesArrays, WithFocusOnLoad, WithConfirmationDialog;
 
     protected string $actionId;
 
@@ -60,7 +61,7 @@ class CheckboxesElement extends Element
 
     public function toArray(): array
     {
-        return $this->toMergedArray([
+        return $this->toMergedArray($this->mergeConfirmationDialog([
             'action_id' => $this->actionId,
             'options' => array_map(function (OptionObject $option): array {
                 return $option->toArray();
@@ -69,6 +70,6 @@ class CheckboxesElement extends Element
                 return $option->toArray();
             }, $this->initialOptions) : null,
             'focus_on_load' => $this->focusOnLoad,
-        ]);
+        ]));
     }
 }

--- a/src/Support/LayoutBlocks/Elements/DatePickerElement.php
+++ b/src/Support/LayoutBlocks/Elements/DatePickerElement.php
@@ -7,11 +7,12 @@ use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Composition\WithFocusOnLoad;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 
 class DatePickerElement extends Element
 {
-    use WithFocusOnLoad, MergesArrays;
+    use WithFocusOnLoad, MergesArrays, WithConfirmationDialog;
 
     protected string $actionId;
 
@@ -46,11 +47,11 @@ class DatePickerElement extends Element
 
     public function toArray(): array
     {
-        return $this->toMergedArray([
+        return $this->toMergedArray($this->mergeConfirmationDialog([
             'action_id' => $this->actionId,
             'initial_date' => $this->initialDate,
             'placeholder' => ($this->placeholder) ? $this->placeholder->toArray() : null,
             'focus_on_load' => $this->focusOnLoad,
-        ]);
+        ]));
     }
 }

--- a/src/Support/LayoutBlocks/Elements/MultiSelect/MultiSelect.php
+++ b/src/Support/LayoutBlocks/Elements/MultiSelect/MultiSelect.php
@@ -6,12 +6,13 @@ namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\MultiSelect;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Composition\WithFocusOnLoad;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MultiSelectElementCompatibility;
 
 abstract class MultiSelect extends Element
 {
-    use MultiSelectElementCompatibility, WithFocusOnLoad;
+    use MultiSelectElementCompatibility, WithFocusOnLoad, WithConfirmationDialog;
 
     protected string $actionId;
 
@@ -33,12 +34,12 @@ abstract class MultiSelect extends Element
 
     public function toArray(): array
     {
-        return [
+        return $this->mergeConfirmationDialog([
             'type' => $this->getType(),
             'action_id' => $this->actionId,
             'placeholder' => $this->placeholder->toArray(),
             'focus_on_load' => $this->focusOnLoad,
             'max_selected_items' => $this->maxSelectedItems,
-        ];
+        ]);
     }
 }

--- a/src/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectConversationElement.php
+++ b/src/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectConversationElement.php
@@ -5,11 +5,12 @@ namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\MultiSelect;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithFilter;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 
 class MultiSelectConversationElement extends MultiSelect
 {
-    use MergesArrays;
+    use MergesArrays, WithFilter;
 
     protected ?array $initialConversations = null;
 
@@ -50,9 +51,9 @@ class MultiSelectConversationElement extends MultiSelect
 
     public function toArray(): array
     {
-        return $this->toMergedArray([
+        return $this->toMergedArray($this->mergeFilter([
             'initial_conversations' => $this->initialConversations,
             'default_to_current_conversation' => $this->defaultToCurrent,
-        ]);
+        ]));
     }
 }

--- a/src/Support/LayoutBlocks/Elements/OverflowMenuElement.php
+++ b/src/Support/LayoutBlocks/Elements/OverflowMenuElement.php
@@ -6,12 +6,13 @@ namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\HasActionId;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 
 class OverflowMenuElement extends Element
 {
-    use MergesArrays, HasActionId;
+    use MergesArrays, HasActionId, WithConfirmationDialog;
 
     /**
      * @var OptionObject[]
@@ -39,11 +40,11 @@ class OverflowMenuElement extends Element
 
     public function toArray(): array
     {
-        return $this->toMergedArray([
+        return $this->toMergedArray($this->mergeConfirmationDialog([
             'action_id' => $this->actionId,
             'options' => array_map(function (OptionObject $option): array {
                 return $option->toArray();
             }, $this->options),
-        ]);
+        ]));
     }
 }

--- a/src/Support/LayoutBlocks/Elements/RadioButtonGroupElement.php
+++ b/src/Support/LayoutBlocks/Elements/RadioButtonGroupElement.php
@@ -7,12 +7,13 @@ use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Composition\WithFocusOnLoad;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\HasActionId;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 
 class RadioButtonGroupElement extends Element
 {
-    use MergesArrays, HasActionId, WithFocusOnLoad;
+    use MergesArrays, HasActionId, WithFocusOnLoad, WithConfirmationDialog;
 
     /**
      * @var OptionObject[]
@@ -53,13 +54,13 @@ class RadioButtonGroupElement extends Element
 
     public function toArray(): array
     {
-        return $this->toMergedArray([
+        return $this->toMergedArray($this->mergeConfirmationDialog([
             'action_id' => $this->actionId,
             'options' => array_map(function (OptionObject $option): array {
                 return $option->toArray();
             }, $this->options),
             'initial_option' => ($this->initialOption) ? $this->initialOption->toArray() : null,
             'focus_on_load' => $this->focusOnLoad,
-        ]);
+        ]));
     }
 }

--- a/src/Support/LayoutBlocks/Elements/SelectMenu/SelectMenu.php
+++ b/src/Support/LayoutBlocks/Elements/SelectMenu/SelectMenu.php
@@ -7,10 +7,11 @@ use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Composition\WithFocusOnLoad;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 
 abstract class SelectMenu extends Element
 {
-    use WithFocusOnLoad;
+    use WithFocusOnLoad, WithConfirmationDialog;
 
     protected string $actionId;
 
@@ -33,11 +34,11 @@ abstract class SelectMenu extends Element
 
     public function toArray(): array
     {
-        return [
+        return $this->mergeConfirmationDialog([
             'type' => $this->getType(),
             'action_id' => $this->actionId,
             'placeholder' => $this->placeholder->toArray(),
             'focus_on_load' => $this->focusOnLoad,
-        ];
+        ]);
     }
 }

--- a/src/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuConversationElement.php
+++ b/src/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuConversationElement.php
@@ -5,11 +5,12 @@ namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\SelectMenu;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\HasInitialOption;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithFilter;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 
 class SelectMenuConversationElement extends SelectMenu
 {
-    use MergesArrays, HasInitialOption;
+    use MergesArrays, HasInitialOption, WithFilter;
 
     protected ?bool $defaultToCurrent = null;
 
@@ -40,9 +41,9 @@ class SelectMenuConversationElement extends SelectMenu
 
     public function toArray(): array
     {
-        return $this->toMergedArray($this->mergeInitialOption([
+        return $this->toMergedArray($this->mergeInitialOption($this->mergeFilter([
             'default_to_current_conversation' => $this->defaultToCurrent,
             'response_url_enabled' => $this->responseUrlEnabled,
-        ]));
+        ])));
     }
 }

--- a/src/Support/LayoutBlocks/Elements/TimePickerElement.php
+++ b/src/Support/LayoutBlocks/Elements/TimePickerElement.php
@@ -7,12 +7,13 @@ use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Composition\WithFocusOnLoad;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements\WithConfirmationDialog;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\HasActionId;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\MergesArrays;
 
 class TimePickerElement extends Element
 {
-    use MergesArrays, HasActionId, WithFocusOnLoad;
+    use MergesArrays, HasActionId, WithFocusOnLoad, WithConfirmationDialog;
 
     protected TextObject $placeholder;
 
@@ -46,11 +47,11 @@ class TimePickerElement extends Element
 
     public function toArray(): array
     {
-        return $this->toMergedArray([
+        return $this->toMergedArray($this->mergeConfirmationDialog([
             'action_id' => $this->actionId,
             'placeholder' => $this->placeholder->toArray(),
             'initial_time' => $this->initialTime,
             'focus_on_load' => $this->focusOnLoad,
-        ]);
+        ]));
     }
 }

--- a/src/Support/LayoutBlocks/Traits/Elements/WithConfirmationDialog.php
+++ b/src/Support/LayoutBlocks/Traits/Elements/WithConfirmationDialog.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
+
+trait WithConfirmationDialog
+{
+    protected ?ConfirmationDialogObject $confirmationDialog = null;
+
+    public function withConfirmationDialog(ConfirmationDialogObject $confirmationDialog): self
+    {
+        $this->confirmationDialog = $confirmationDialog;
+        return $this;
+    }
+
+    protected function mergeConfirmationDialog(array $mergeWith): array
+    {
+        return array_merge($mergeWith, [
+            'confirm' => ($this->confirmationDialog) ? $this->confirmationDialog->toArray() : null,
+        ]);
+    }
+}

--- a/src/Support/LayoutBlocks/Traits/Elements/WithFilter.php
+++ b/src/Support/LayoutBlocks/Traits/Elements/WithFilter.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Support\LayoutBlocks\Traits\Elements;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\FilterObject;
+
+trait WithFilter
+{
+    protected ?FilterObject $filter = null;
+
+    public function withFilter(FilterObject $filter): self
+    {
+        $this->filter = $filter;
+        return $this;
+    }
+
+    protected function mergeFilter(array $mergeWith): array
+    {
+        return array_filter(array_merge($mergeWith, [
+            'filter' => ($this->filter) ? $this->filter->toArray() : null,
+        ]));
+    }
+}

--- a/tests/Unit/Support/LayoutBlocks/Composition/ConfirmationDialogObjectTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Composition/ConfirmationDialogObjectTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
+use Tests\TestCase;
+
+class ConfirmationDialogObjectTest extends TestCase
+{
+    public function testObject()
+    {
+        $expectedTitleArray = ['k1' => 'v1'];
+        $expectedTextArray = ['k2' => 'v2'];
+        $expectedConfirmArray = ['k3' => 'v3'];
+        $expectedDenyArray = ['k4' => 'v4'];
+
+        $title = \Mockery::mock(TextObject::class);
+        $text = \Mockery::mock(TextObject::class);
+        $confirm = \Mockery::mock(TextObject::class);
+        $deny = \Mockery::mock(TextObject::class);
+
+        $title->shouldReceive('toArray')->andReturn($expectedTitleArray);
+        $text->shouldReceive('toArray')->andReturn($expectedTextArray);
+        $confirm->shouldReceive('toArray')->andReturn($expectedConfirmArray);
+        $deny->shouldReceive('toArray')->andReturn($expectedDenyArray);
+
+        $object = new ConfirmationDialogObject($title, $text, $confirm, $deny);
+
+        $this->assertEquals([
+            'title' => $expectedTitleArray,
+            'text' => $expectedTextArray,
+            'confirm' => $expectedConfirmArray,
+            'deny' => $expectedDenyArray,
+        ], $object->toArray());
+    }
+
+    public function testObjectWithButtonPrimary()
+    {
+        $expectedTitleArray = ['k1' => 'v1'];
+        $expectedTextArray = ['k2' => 'v2'];
+        $expectedConfirmArray = ['k3' => 'v3'];
+        $expectedDenyArray = ['k4' => 'v4'];
+
+        $title = \Mockery::mock(TextObject::class);
+        $text = \Mockery::mock(TextObject::class);
+        $confirm = \Mockery::mock(TextObject::class);
+        $deny = \Mockery::mock(TextObject::class);
+
+        $title->shouldReceive('toArray')->andReturn($expectedTitleArray);
+        $text->shouldReceive('toArray')->andReturn($expectedTextArray);
+        $confirm->shouldReceive('toArray')->andReturn($expectedConfirmArray);
+        $deny->shouldReceive('toArray')->andReturn($expectedDenyArray);
+
+        $object = new ConfirmationDialogObject($title, $text, $confirm, $deny);
+        $object->confirmButtonPrimary();
+
+        $this->assertEquals([
+            'title' => $expectedTitleArray,
+            'text' => $expectedTextArray,
+            'confirm' => $expectedConfirmArray,
+            'deny' => $expectedDenyArray,
+            'style' => 'primary',
+        ], $object->toArray());
+    }
+
+    public function testObjectWithButtonDanger()
+    {
+        $expectedTitleArray = ['k1' => 'v1'];
+        $expectedTextArray = ['k2' => 'v2'];
+        $expectedConfirmArray = ['k3' => 'v3'];
+        $expectedDenyArray = ['k4' => 'v4'];
+
+        $title = \Mockery::mock(TextObject::class);
+        $text = \Mockery::mock(TextObject::class);
+        $confirm = \Mockery::mock(TextObject::class);
+        $deny = \Mockery::mock(TextObject::class);
+
+        $title->shouldReceive('toArray')->andReturn($expectedTitleArray);
+        $text->shouldReceive('toArray')->andReturn($expectedTextArray);
+        $confirm->shouldReceive('toArray')->andReturn($expectedConfirmArray);
+        $deny->shouldReceive('toArray')->andReturn($expectedDenyArray);
+
+        $object = new ConfirmationDialogObject($title, $text, $confirm, $deny);
+        $object->confirmButtonDanger();
+
+        $this->assertEquals([
+            'title' => $expectedTitleArray,
+            'text' => $expectedTextArray,
+            'confirm' => $expectedConfirmArray,
+            'deny' => $expectedDenyArray,
+            'style' => 'danger',
+        ], $object->toArray());
+    }
+}

--- a/tests/Unit/Support/LayoutBlocks/Composition/DispatchActionConfigurationObjectTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Composition/DispatchActionConfigurationObjectTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\DispatchActionConfigurationObject;
+use Tests\TestCase;
+
+class DispatchActionConfigurationObjectTest extends TestCase
+{
+    public function testObject()
+    {
+        $triggerActionsOn = ['on_enter_pressed', 'on_character_entered'];
+        $object = new DispatchActionConfigurationObject();
+
+        $object->onEnterPressed();
+        $object->onCharacterEntered();
+
+        $this->assertEquals([
+            'trigger_actions_on' => $triggerActionsOn,
+        ], $object->toArray());
+    }
+
+    public function testObjectNoTriggers()
+    {
+        $object = new DispatchActionConfigurationObject();
+        $this->assertEquals([], $object->toArray());
+    }
+}

--- a/tests/Unit/Support/LayoutBlocks/Composition/FilterObjectTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Composition/FilterObjectTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\FilterObject;
+use Tests\TestCase;
+
+class FilterObjectTest extends TestCase
+{
+    public function testObject()
+    {
+        $object = new FilterObject();
+        $this->assertEmpty($object->toArray());
+    }
+
+    public function testObjectWithAllOptions()
+    {
+        $object = new FilterObject();
+
+        $object->includeConversationTypes(['public', 'private']);
+        $object->excludeExternalSharedChannels();
+        $object->excludeBotUsers();
+
+        $this->assertEquals([
+            'include' => ['public', 'private'],
+            'exclude_external_shared_channels' => true,
+            'exclude_bot_users' => true,
+        ], $object->toArray());
+    }
+}

--- a/tests/Unit/Support/LayoutBlocks/Composition/OptionGroupObjectTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Composition/OptionGroupObjectTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\LayoutBlocks\Composition;
+
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionGroupObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
+use Tests\TestCase;
+
+class OptionGroupObjectTest extends TestCase
+{
+    public function testObject()
+    {
+        $expectedLabelArray = ['k1' => 'v1'];
+        $expectedOption1Array = ['k2' => 'v2'];
+        $expectedOption2Array = ['k3' => 'v3'];
+
+        $label = \Mockery::mock(TextObject::class);
+        $option1 = \Mockery::mock(OptionObject::class);
+        $option2 = \Mockery::mock(OptionObject::class);
+
+        $label->shouldReceive('toArray')->andReturn($expectedLabelArray);
+        $option1->shouldReceive('toArray')->andReturn($expectedOption1Array);
+        $option2->shouldReceive('toArray')->andReturn($expectedOption2Array);
+
+        $object = new OptionGroupObject($label, [$option1, $option2]);
+
+        $this->assertEquals([
+            'label' => $expectedLabelArray,
+            'options' => [$expectedOption1Array, $expectedOption2Array],
+        ], $object->toArray());
+    }
+}

--- a/tests/Unit/Support/LayoutBlocks/Elements/ButtonElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/ButtonElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\ButtonElement;
@@ -32,15 +33,20 @@ class ButtonElementTest extends TestCase
     public function testElementWithOptions()
     {
         $expectedTextObjectArray = ['key' => 'value'];
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
 
         $textObject = \Mockery::mock(TextObject::class);
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+
         $textObject->shouldReceive('toArray')->andReturn($expectedTextObjectArray);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
 
         $actionId = 'action-id';
 
         $element = new ButtonElement($textObject, $actionId);
         $element->withUrl('https://example.com', 'url value');
         $element->withAccessibilityLabel('accessibility label');
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_BUTTON,
@@ -49,6 +55,7 @@ class ButtonElementTest extends TestCase
             'url' => 'https://example.com',
             'value' => 'url value',
             'accessibility_label' => 'accessibility label',
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 

--- a/tests/Unit/Support/LayoutBlocks/Elements/CheckboxesElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/CheckboxesElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\CheckboxesElement;
@@ -40,19 +41,23 @@ class CheckboxesElementTest extends TestCase
     {
         $actionId = 'action-id';
 
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
         $expectedOption1Array = ['key' => 'val'];
         $expectedOption2Array = ['key2' => 'val2'];
 
         $option1 = \Mockery::mock(OptionObject::class);
         $option2 = \Mockery::mock(OptionObject::class);
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
 
         $option1->shouldReceive('toArray')->andReturn($expectedOption1Array);
         $option2->shouldReceive('toArray')->andReturn($expectedOption2Array);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
 
         $element = new CheckboxesElement($actionId, [$option1, $option2]);
 
         $element->withInitialOptions([$option1, $option2]);
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_CHECKBOXES,
@@ -66,6 +71,7 @@ class CheckboxesElementTest extends TestCase
                 $expectedOption2Array,
             ],
             'focus_on_load' => true,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 

--- a/tests/Unit/Support/LayoutBlocks/Elements/DatePickerElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/DatePickerElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\DatePickerElement;
@@ -31,12 +32,17 @@ class DatePickerElementTest extends TestCase
         $element = new DatePickerElement($actionId, $initialDate);
 
         $expectedPlaceholderTextArray = ['key' => 'val'];
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
 
         $placeholderTextObject = \Mockery::mock(TextObject::class);
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+
         $placeholderTextObject->shouldReceive('toArray')->andReturn($expectedPlaceholderTextArray);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
 
         $element->withPlaceholder($placeholderTextObject);
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_DATEPICKER,
@@ -44,6 +50,7 @@ class DatePickerElementTest extends TestCase
             'initial_date' => $initialDate,
             'placeholder' => $expectedPlaceholderTextArray,
             'focus_on_load' => true,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 

--- a/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectConversationElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectConversationElementTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\MultiSelect;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\FilterObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\MultiSelect\MultiSelectConversationElement;
@@ -40,6 +42,14 @@ class MultiSelectConversationElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
+        $expectedFilterArray = ['filter' => 'value'];
+        $filter = \Mockery::mock(FilterObject::class);
+        $filter->shouldReceive('toArray')->andReturn($expectedFilterArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $actionId = 'action-id';
@@ -54,6 +64,8 @@ class MultiSelectConversationElementTest extends TestCase
         $element->maxSelectedItems(5);
         $element->withFocusOnLoad();
         $element->defaultToCurrent();
+        $element->withConfirmationDialog($confirmationDialogObject);
+        $element->withFilter($filter);
 
         $this->assertEquals([
             'type' => Element::TYPE_MULTI_SELECT_CONVERSATIONS,
@@ -63,6 +75,8 @@ class MultiSelectConversationElementTest extends TestCase
             'max_selected_items' => 5,
             'initial_conversations' => $initialConversations,
             'default_to_current_conversation' => true,
+            'confirm' => $expectedConfirmationDialogArray,
+            'filter' => $expectedFilterArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectExternalElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectExternalElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements\MultiSelect;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
@@ -42,6 +43,10 @@ class MultiSelectExternalElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'val'];
 
         $actionId = 'action-id';
@@ -63,6 +68,7 @@ class MultiSelectExternalElementTest extends TestCase
         $element->withFocusOnLoad();
         $element->withInitialOptions([$option1, $option2]);
         $element->maxSelectedItems(1);
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_MULTI_SELECT_EXTERNAL,
@@ -75,6 +81,7 @@ class MultiSelectExternalElementTest extends TestCase
             'focus_on_load' => true,
             'max_selected_items' => 1,
             'min_query_length' => 5,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 

--- a/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectPublicChannelElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectPublicChannelElementTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\MultiSelect;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\MultiSelect\MultiSelectConversationElement;
@@ -41,6 +42,10 @@ class MultiSelectPublicChannelElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $actionId = 'action-id';
@@ -54,6 +59,7 @@ class MultiSelectPublicChannelElementTest extends TestCase
         $element->withInitialChannels($initialChannels);
         $element->maxSelectedItems(5);
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_MULTI_SELECT_CHANNELS,
@@ -62,6 +68,7 @@ class MultiSelectPublicChannelElementTest extends TestCase
             'focus_on_load' => true,
             'max_selected_items' => 5,
             'initial_channels' => $initialChannels,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectStaticElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectStaticElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements\MultiSelect;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
@@ -56,6 +57,10 @@ class MultiSelectStaticElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'val'];
 
         $actionId = 'action-id';
@@ -76,6 +81,7 @@ class MultiSelectStaticElementTest extends TestCase
         $element->withFocusOnLoad();
         $element->withInitialOptions([$option1, $option2]);
         $element->maxSelectedItems(1);
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_MULTI_SELECT_STATIC,
@@ -91,6 +97,7 @@ class MultiSelectStaticElementTest extends TestCase
             ],
             'focus_on_load' => true,
             'max_selected_items' => 1,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectUserElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/MultiSelect/MultiSelectUserElementTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\MultiSelect;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\MultiSelect\MultiSelectUserElement;
@@ -40,6 +41,10 @@ class MultiSelectUserElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $actionId = 'action-id';
@@ -53,6 +58,7 @@ class MultiSelectUserElementTest extends TestCase
         $element->withInitialUsers($initialUsers);
         $element->maxSelectedItems(5);
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_MULTI_SELECT_USERS,
@@ -61,6 +67,7 @@ class MultiSelectUserElementTest extends TestCase
             'focus_on_load' => true,
             'max_selected_items' => 5,
             'initial_users' => $initialUsers,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/OverflowMenuElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/OverflowMenuElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\OverflowMenuElement;
@@ -30,6 +31,39 @@ class OverflowMenuElementTest extends TestCase
             'type' => Element::TYPE_OVERFLOW_MENU,
             'action_id' => $actionId,
             'options' => [$expectedOption1Array, $expectedOption2Array],
+        ], $element->toArray());
+
+        $this->assertEquals([
+            Block::TYPE_SECTION,
+            Block::TYPE_ACTIONS,
+        ], $element->compatibleWith());
+    }
+
+    public function testElementWithOptions()
+    {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
+        $expectedOption1Array = ['k1' => 'v1'];
+        $expectedOption2Array = ['k2' => 'v2'];
+
+        $option1 = \Mockery::mock(OptionObject::class);
+        $option2 = \Mockery::mock(OptionObject::class);
+
+        $option1->shouldReceive('toArray')->andReturn($expectedOption1Array);
+        $option2->shouldReceive('toArray')->andReturn($expectedOption2Array);
+
+        $actionId = 'action-id';
+
+        $element = new OverflowMenuElement($actionId, [$option1, $option2]);
+        $element->withConfirmationDialog($confirmationDialogObject);
+
+        $this->assertEquals([
+            'type' => Element::TYPE_OVERFLOW_MENU,
+            'action_id' => $actionId,
+            'options' => [$expectedOption1Array, $expectedOption2Array],
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
 
         $this->assertEquals([

--- a/tests/Unit/Support/LayoutBlocks/Elements/RadioButtonGroupElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/RadioButtonGroupElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\RadioButtonGroupElement;
@@ -35,6 +36,10 @@ class RadioButtonGroupElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedOption1Array = ['k1' => 'v1'];
         $expectedOption2Array = ['k2' => 'v2'];
 
@@ -50,6 +55,7 @@ class RadioButtonGroupElementTest extends TestCase
 
         $element->withInitialOption($option1);
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_RADIO_BUTTON_GROUP,
@@ -57,6 +63,7 @@ class RadioButtonGroupElementTest extends TestCase
             'options' => [$expectedOption1Array, $expectedOption2Array],
             'focus_on_load' => true,
             'initial_option' => $expectedOption1Array,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 

--- a/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuConversationElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuConversationElementTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\SelectMenu;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\FilterObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\SelectMenu\SelectMenuConversationElement;
@@ -40,6 +42,14 @@ class SelectMenuConversationElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
+        $expectedFilterArray = ['filter' => 'value'];
+        $filter = \Mockery::mock(FilterObject::class);
+        $filter->shouldReceive('toArray')->andReturn($expectedFilterArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $placeholder = \Mockery::mock(TextObject::class);
@@ -52,6 +62,8 @@ class SelectMenuConversationElementTest extends TestCase
         $element->withFocusOnLoad();
         $element->withResponseUrlEnabled();
         $element->defaultToCurrent();
+        $element->withConfirmationDialog($confirmationDialogObject);
+        $element->withFilter($filter);
 
         $this->assertEquals([
             'type' => Element::TYPE_SELECT_MENU_CONVERSATIONS,
@@ -61,6 +73,8 @@ class SelectMenuConversationElementTest extends TestCase
             'focus_on_load' => true,
             'response_url_enabled' => true,
             'default_to_current_conversation' => true,
+            'confirm' => $expectedConfirmationDialogArray,
+            'filter' => $expectedFilterArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuExternalElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuExternalElementTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\SelectMenu;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
@@ -41,6 +42,10 @@ class SelectMenuExternalElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $placeholder = \Mockery::mock(TextObject::class);
@@ -61,6 +66,7 @@ class SelectMenuExternalElementTest extends TestCase
         $element->withMinQueryLength(5);
         $element->withInitialOption($option1);
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_SELECT_MENU_EXTERNAL,
@@ -69,6 +75,7 @@ class SelectMenuExternalElementTest extends TestCase
             'initial_option' => $expectedOption1Array,
             'focus_on_load' => true,
             'min_query_length' => 5,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuPublicChannelElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuPublicChannelElementTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\SelectMenu;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\SelectMenu\SelectMenuPublicChannelElement;
@@ -40,6 +41,10 @@ class SelectMenuPublicChannelElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $placeholder = \Mockery::mock(TextObject::class);
@@ -51,6 +56,7 @@ class SelectMenuPublicChannelElementTest extends TestCase
         $element->withInitialOption('general');
         $element->withFocusOnLoad();
         $element->withResponseUrlEnabled();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_SELECT_MENU_CHANNELS,
@@ -59,6 +65,7 @@ class SelectMenuPublicChannelElementTest extends TestCase
             'initial_channel' => 'general',
             'focus_on_load' => true,
             'response_url_enabled' => true,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuStaticElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuStaticElementTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\SelectMenu;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
@@ -52,6 +53,10 @@ class SelectMenuStaticElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $placeholder = \Mockery::mock(TextObject::class);
@@ -71,6 +76,7 @@ class SelectMenuStaticElementTest extends TestCase
 
         $element->withInitialOption($option1);
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_SELECT_MENU_STATIC,
@@ -79,6 +85,7 @@ class SelectMenuStaticElementTest extends TestCase
             'options' => [$expectedOption1Array, $expectedOption2Array],
             'initial_option' => $expectedOption1Array,
             'focus_on_load' => true,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuUserElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/SelectMenu/SelectMenuUserElementTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Support\LayoutBlocks\Elements\SelectMenu;
 
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\OptionObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
@@ -41,6 +42,10 @@ class SelectMenuUserElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $placeholder = \Mockery::mock(TextObject::class);
@@ -51,6 +56,7 @@ class SelectMenuUserElementTest extends TestCase
 
         $element->withInitialOption('username');
         $element->withFocusOnLoad();
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_SELECT_MENU_USERS,
@@ -58,6 +64,7 @@ class SelectMenuUserElementTest extends TestCase
             'placeholder' => $expectedPlaceholderArray,
             'initial_user' => 'username',
             'focus_on_load' => true,
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 }

--- a/tests/Unit/Support/LayoutBlocks/Elements/TimePickerElementTest.php
+++ b/tests/Unit/Support/LayoutBlocks/Elements/TimePickerElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Support\LayoutBlocks\Elements;
 
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Block;
+use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\ConfirmationDialogObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Composition\TextObject;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Element;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\TimePickerElement;
@@ -31,6 +32,10 @@ class TimePickerElementTest extends TestCase
 
     public function testElementWithOptions()
     {
+        $expectedConfirmationDialogArray = ['key2' => 'value2'];
+        $confirmationDialogObject = \Mockery::mock(ConfirmationDialogObject::class);
+        $confirmationDialogObject->shouldReceive('toArray')->andReturn($expectedConfirmationDialogArray);
+
         $expectedPlaceholderArray = ['key' => 'value'];
 
         $placeholder = \Mockery::mock(TextObject::class);
@@ -42,6 +47,7 @@ class TimePickerElementTest extends TestCase
 
         $element->withFocusOnLoad();
         $element->withInitialTime('10:00:00');
+        $element->withConfirmationDialog($confirmationDialogObject);
 
         $this->assertEquals([
             'type' => Element::TYPE_TIME_PICKER,
@@ -49,6 +55,7 @@ class TimePickerElementTest extends TestCase
             'placeholder' => $expectedPlaceholderArray,
             'focus_on_load' => true,
             'initial_time' => '10:00:00',
+            'confirm' => $expectedConfirmationDialogArray,
         ], $element->toArray());
     }
 


### PR DESCRIPTION
Closes #4 

---

Adds remaining composition objects:
* Confirmation dialog
* Dispatch action configuration
* Option group
* Filter