### PR TITLE
#18: allow laravel/slack-notification-channel to be used alongside this package

### DIFF
--- a/config/slack.php
+++ b/config/slack.php
@@ -4,4 +4,5 @@ declare(strict_types=1);
 return [
     'bot_token' => env('SLACK_API_BOT_TOKEN'),
     'api_url' => env('SLACK_API_URL', 'https://slack.com/api'),
+    'driver_name' => env('SLACK_API_DRIVER_NAME', 'slack'),
 ];

--- a/examples/blocks-with-header.md
+++ b/examples/blocks-with-header.md
@@ -10,11 +10,12 @@ namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
+use Nwilging\LaravelSlackBot\Contracts\Notifications\SlackApiNotificationContract;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Blocks\SectionBlock;
 use Nwilging\LaravelSlackBot\Support\LayoutBuilder\Builder;
 use Nwilging\LaravelSlackBot\Support\SlackOptionsBuilder;
 
-class TestNotification extends Notification
+class TestNotification extends Notification implements SlackApiNotificationContract
 {
     use Queueable;
 
@@ -29,7 +30,7 @@ class TestNotification extends Notification
         return ['slack'];
     }
 
-    public function toSlack(): array
+    public function toSlackArray(): array
     {
         $options = new SlackOptionsBuilder();
         $options->username('My Bot')

--- a/examples/section-with-button.md
+++ b/examples/section-with-button.md
@@ -10,12 +10,13 @@ namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
+use Nwilging\LaravelSlackBot\Contracts\Notifications\SlackApiNotificationContract;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Blocks\SectionBlock;
 use Nwilging\LaravelSlackBot\Support\LayoutBlocks\Elements\ButtonElement;
 use Nwilging\LaravelSlackBot\Support\LayoutBuilder\Builder;
 use Nwilging\LaravelSlackBot\Support\SlackOptionsBuilder;
 
-class TestNotification extends Notification
+class TestNotification extends Notification implements SlackApiNotificationContract
 {
     use Queueable;
 
@@ -30,7 +31,7 @@ class TestNotification extends Notification
         return ['slack'];
     }
 
-    public function toSlack(): array
+    public function toSlackArray(): array
     {
         $options = new SlackOptionsBuilder();
         $options->username('My Bot')

--- a/examples/simple-text.md
+++ b/examples/simple-text.md
@@ -10,9 +10,10 @@ namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
+use Nwilging\LaravelSlackBot\Contracts\Notifications\SlackApiNotificationContract;
 use Nwilging\LaravelSlackBot\Support\SlackOptionsBuilder;
 
-class TestNotification extends Notification
+class TestNotification extends Notification implements SlackApiNotificationContract
 {
     use Queueable;
 
@@ -27,7 +28,7 @@ class TestNotification extends Notification
         return ['slack'];
     }
 
-    public function toSlack(): array
+    public function toSlackArray(): array
     {
         $options = new SlackOptionsBuilder();
         $options->username('My Bot')

--- a/src/Channels/SlackNotificationChannel.php
+++ b/src/Channels/SlackNotificationChannel.php
@@ -6,6 +6,7 @@ namespace Nwilging\LaravelSlackBot\Channels;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Nwilging\LaravelSlackBot\Contracts\Channels\SlackNotificationChannelContract;
+use Nwilging\LaravelSlackBot\Contracts\Notifications\SlackApiNotificationContract;
 use Nwilging\LaravelSlackBot\Contracts\SlackApiServiceContract;
 
 class SlackNotificationChannel implements SlackNotificationChannelContract
@@ -19,12 +20,12 @@ class SlackNotificationChannel implements SlackNotificationChannelContract
 
     /**
      * @param Notifiable $notifiable
-     * @param Notification $notification
+     * @param SlackApiNotificationContract $notification
      * @return void
      */
-    public function send($notifiable, Notification $notification): void
+    public function send($notifiable, SlackApiNotificationContract $notification): void
     {
-        $slackNotificationArray = $notification->toSlack();
+        $slackNotificationArray = $notification->toSlackArray();
         switch ($slackNotificationArray['contentType']) {
             case 'text':
                 $this->handleTextMessage($slackNotificationArray);

--- a/src/Contracts/Channels/SlackNotificationChannelContract.php
+++ b/src/Contracts/Channels/SlackNotificationChannelContract.php
@@ -3,9 +3,18 @@ declare(strict_types=1);
 
 namespace Nwilging\LaravelSlackBot\Contracts\Channels;
 
-use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Notifiable;
+use Nwilging\LaravelSlackBot\Contracts\Notifications\SlackApiNotificationContract;
 
 interface SlackNotificationChannelContract
 {
-    public function send($notifiable, Notification $notification): void;
+    /**
+     * Send a notification via the Slack API. The `$notification` should be an implementation of
+     * the SlackApiNotificationContract.
+     *
+     * @param Notifiable $notifiable
+     * @param SlackApiNotificationContract $notification
+     * @return void
+     */
+    public function send($notifiable, SlackApiNotificationContract $notification): void;
 }

--- a/src/Contracts/Notifications/SlackApiNotificationContract.php
+++ b/src/Contracts/Notifications/SlackApiNotificationContract.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Contracts\Notifications;
+
+interface SlackApiNotificationContract
+{
+    /**
+     * Returns a Slack-API compliant notification array.
+     *
+     * @return array{
+     *      contentType: 'text'|'blocks',
+     *      channelId: string,
+     *      text?: string,
+     *      blocks?: Block[],
+     *      options?: array,
+     * }
+     */
+    public function toSlackArray(): array;
+}

--- a/src/Providers/SlackBotServiceProvider.php
+++ b/src/Providers/SlackBotServiceProvider.php
@@ -26,7 +26,8 @@ class SlackBotServiceProvider extends ServiceProvider
     public function register()
     {
         Notification::resolved(function (ChannelManager $channelManager): void {
-            $channelManager->extend('slack', function (): SlackNotificationChannelContract {
+            $driverName = $this->app->make(Config::class)->get('slack.driver_name');
+            $channelManager->extend($driverName, function (): SlackNotificationChannelContract {
                 return $this->app->make(SlackNotificationChannelContract::class);
             });
         });

--- a/tests/Unit/Channels/SlackNotificationChannelTest.php
+++ b/tests/Unit/Channels/SlackNotificationChannelTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Channels;
 use Illuminate\Notifications\Notification;
 use Mockery\MockInterface;
 use Nwilging\LaravelSlackBot\Channels\SlackNotificationChannel;
+use Nwilging\LaravelSlackBot\Contracts\Notifications\SlackApiNotificationContract;
 use Nwilging\LaravelSlackBot\Contracts\SlackApiServiceContract;
 use Tests\TestCase;
 
@@ -26,8 +27,8 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendThrowsInvalidArgumentException()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification {
-            public function toSlack(): array
+        $notification = new class extends Notification implements SlackApiNotificationContract {
+            public function toSlackArray(): array
             {
                 return [
                     'contentType' => 'invalid-type',
@@ -44,8 +45,8 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendSendsTextMessage()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification {
-            public function toSlack(): array
+        $notification = new class extends Notification implements SlackApiNotificationContract{
+            public function toSlackArray(): array
             {
                 return [
                     'channelId' => 'C12345',
@@ -68,8 +69,8 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendTextMessageSendsEmptyOptionsArray()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification {
-            public function toSlack(): array
+        $notification = new class extends Notification implements SlackApiNotificationContract{
+            public function toSlackArray(): array
             {
                 return [
                     'channelId' => 'C12345',
@@ -89,8 +90,8 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendBlocksMessage()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification {
-            public function toSlack(): array
+        $notification = new class extends Notification implements SlackApiNotificationContract{
+            public function toSlackArray(): array
             {
                 return [
                     'channelId' => 'C12345',
@@ -113,8 +114,8 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendBlocksMessageSendsEmptyOptionsArray()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification {
-            public function toSlack(): array
+        $notification = new class extends Notification implements SlackApiNotificationContract {
+            public function toSlackArray(): array
             {
                 return [
                     'channelId' => 'C12345',


### PR DESCRIPTION
Closes #18 

---

Adds ability to configure driver name for this package. **The driver name will still be `slack` by default**. If a user wishes to change the driver name, add the following to `.env`:
```
SLACK_API_DRIVER_NAME=<driver-name>
```

For example:
```
SLACK_API_DRIVER_NAME=slackBot
```

This will allow `slackBot` to be specified in `via()`.

---

Also adds a `SlackApiNotificationContract` that _must_ be implemented by the notification and requires a `toSlackArray(): array` method to be defined. This is to avoid conflicts with `laravel/slack-notification-channel`'s `toSlack()` method.

---

I've been using the minor version to increment on breaking changes. To comply with semantic versioning this should release as `1.0.0`.