### PR TITLE
#20: Add $notifiable parameter to toSlackArray method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class SlackNotification extends Notification implements SlackApiNotificationCont
         return ['slackBot']
     }
 
-    public function toSlackArray(): array
+    public function toSlackArray($notifiable): array
     {
         return [
             'contentType' => 'text',
@@ -130,7 +130,7 @@ class SlackNotification extends Notification implements SlackApiNotificationCont
         return ['slack']; // Or, `via['slackBot']` if you have configured this in .env
     }
 
-    public function toSlackArray(): array
+    public function toSlackArray($notifiable): array
     {
         return [
             'contentType' => 'text',
@@ -174,7 +174,7 @@ class SlackNotification extends Notification implements SlackApiNotificationCont
     /**
      * The method to build a slack message for laravel/slack-notification-channel
      */
-    public function toSlack()
+    public function toSlack($notifiable)
     {
         // 
     }
@@ -182,7 +182,7 @@ class SlackNotification extends Notification implements SlackApiNotificationCont
     /**
      * The method to build a slack message for nwilging/laravel-slack-bot
      */
-    public function toSlackArray(): array
+    public function toSlackArray($notifiable): array
     {
         return [
             'contentType' => 'text',

--- a/examples/blocks-with-header.md
+++ b/examples/blocks-with-header.md
@@ -30,7 +30,7 @@ class TestNotification extends Notification implements SlackApiNotificationContr
         return ['slack'];
     }
 
-    public function toSlackArray(): array
+    public function toSlackArray($notifiable): array
     {
         $options = new SlackOptionsBuilder();
         $options->username('My Bot')

--- a/examples/section-with-button.md
+++ b/examples/section-with-button.md
@@ -31,7 +31,7 @@ class TestNotification extends Notification implements SlackApiNotificationContr
         return ['slack'];
     }
 
-    public function toSlackArray(): array
+    public function toSlackArray($notifiable): array
     {
         $options = new SlackOptionsBuilder();
         $options->username('My Bot')

--- a/examples/simple-text.md
+++ b/examples/simple-text.md
@@ -28,7 +28,7 @@ class TestNotification extends Notification implements SlackApiNotificationContr
         return ['slack'];
     }
 
-    public function toSlackArray(): array
+    public function toSlackArray($notifiable): array
     {
         $options = new SlackOptionsBuilder();
         $options->username('My Bot')

--- a/src/Channels/SlackNotificationChannel.php
+++ b/src/Channels/SlackNotificationChannel.php
@@ -25,7 +25,7 @@ class SlackNotificationChannel implements SlackNotificationChannelContract
      */
     public function send($notifiable, SlackApiNotificationContract $notification): void
     {
-        $slackNotificationArray = $notification->toSlackArray();
+        $slackNotificationArray = $notification->toSlackArray($notifiable);
         switch ($slackNotificationArray['contentType']) {
             case 'text':
                 $this->handleTextMessage($slackNotificationArray);

--- a/src/Contracts/Notifications/SlackApiNotificationContract.php
+++ b/src/Contracts/Notifications/SlackApiNotificationContract.php
@@ -8,6 +8,7 @@ interface SlackApiNotificationContract
     /**
      * Returns a Slack-API compliant notification array.
      *
+     * @param mixed $notifiable
      * @return array{
      *      contentType: 'text'|'blocks',
      *      channelId: string,
@@ -16,5 +17,5 @@ interface SlackApiNotificationContract
      *      options?: array,
      * }
      */
-    public function toSlackArray(): array;
+    public function toSlackArray($notifiable): array;
 }

--- a/tests/Unit/Channels/SlackNotificationChannelTest.php
+++ b/tests/Unit/Channels/SlackNotificationChannelTest.php
@@ -27,14 +27,13 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendThrowsInvalidArgumentException()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification implements SlackApiNotificationContract {
-            public function toSlackArray(): array
-            {
-                return [
-                    'contentType' => 'invalid-type',
-                ];
-            }
-        };
+        $notification = \Mockery::mock(SlackApiNotificationContract::class);
+        $notification->shouldReceive('toSlackArray')
+            ->once()
+            ->with($notifiable)
+            ->andReturn([
+                'contentType' => 'invalid-type',
+            ]);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid-type is not a valid content type. Use `blocks` or `text`');
@@ -45,19 +44,18 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendSendsTextMessage()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification implements SlackApiNotificationContract{
-            public function toSlackArray(): array
-            {
-                return [
-                    'channelId' => 'C12345',
-                    'contentType' => 'text',
-                    'message' => 'test message',
-                    'options' => [
-                        'key' => 'value',
-                    ],
-                ];
-            }
-        };
+        $notification = \Mockery::mock(SlackApiNotificationContract::class);
+        $notification->shouldReceive('toSlackArray')
+            ->once()
+            ->with($notifiable)
+            ->andReturn([
+                'channelId' => 'C12345',
+                'contentType' => 'text',
+                'message' => 'test message',
+                'options' => [
+                    'key' => 'value',
+                ],
+            ]);
 
         $this->slackApiService->shouldReceive('sendTextMessage')
             ->once()
@@ -69,16 +67,15 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendTextMessageSendsEmptyOptionsArray()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification implements SlackApiNotificationContract{
-            public function toSlackArray(): array
-            {
-                return [
-                    'channelId' => 'C12345',
-                    'contentType' => 'text',
-                    'message' => 'test message',
-                ];
-            }
-        };
+        $notification = \Mockery::mock(SlackApiNotificationContract::class);
+        $notification->shouldReceive('toSlackArray')
+            ->once()
+            ->with($notifiable)
+            ->andReturn([
+                'channelId' => 'C12345',
+                'contentType' => 'text',
+                'message' => 'test message',
+            ]);
 
         $this->slackApiService->shouldReceive('sendTextMessage')
             ->once()
@@ -90,17 +87,16 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendBlocksMessage()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification implements SlackApiNotificationContract{
-            public function toSlackArray(): array
-            {
-                return [
-                    'channelId' => 'C12345',
-                    'contentType' => 'blocks',
-                    'blocks' => [1, 2, 3],
-                    'options' => ['key' => 'value'],
-                ];
-            }
-        };
+        $notification = \Mockery::mock(SlackApiNotificationContract::class);
+        $notification->shouldReceive('toSlackArray')
+            ->once()
+            ->with($notifiable)
+            ->andReturn([
+                'channelId' => 'C12345',
+                'contentType' => 'blocks',
+                'blocks' => [1, 2, 3],
+                'options' => ['key' => 'value'],
+            ]);
 
         $expectedBlocks = [1, 2, 3];
 
@@ -114,16 +110,15 @@ class SlackNotificationChannelTest extends TestCase
     public function testSendBlocksMessageSendsEmptyOptionsArray()
     {
         $notifiable = \Mockery::mock(\stdClass::class);
-        $notification = new class extends Notification implements SlackApiNotificationContract {
-            public function toSlackArray(): array
-            {
-                return [
-                    'channelId' => 'C12345',
-                    'contentType' => 'blocks',
-                    'blocks' => [1, 2, 3],
-                ];
-            }
-        };
+        $notification = \Mockery::mock(SlackApiNotificationContract::class);
+        $notification->shouldReceive('toSlackArray')
+            ->once()
+            ->with($notifiable)
+            ->andReturn([
+                'channelId' => 'C12345',
+                'contentType' => 'blocks',
+                'blocks' => [1, 2, 3],
+            ]);
 
         $expectedBlocks = [1, 2, 3];
 


### PR DESCRIPTION
Closes #20 

---

Sends the `$notifiable` to the `toSlackArray` method of the notification. This is standard laravel practice: https://laravel.com/docs/9.x/notifications#sending-notifications