### PR TITLE
Add slash command handling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,62 @@ $layoutBuilder
 // Pass this to `sendBlocksMessage`
 $apiServiceCompliantBlocksArray = $layoutBuilder->getBlocks();
 ```
+
+## Handling Slash Commands
+
+[Slack Slash Commands](https://api.slack.com/interactivity/slash-commands#creating_commands) can
+be handled via this package and command handlers that are configured in your application.
+
+The `Nwilging\LaravelSlackBot\Services\SlackCommandHandlerService` has a `handle` method
+which accepts a `Request` object. This service will validate the incoming message using the
+request headers and your supplied signing secret, and will then attempt to handle the command
+request with a registered command handler.
+
+### Creating Command Handlers
+
+Command handlers should implement the interface `Nwilging\LaravelSlackBot\Contracts\SlackCommandHandlerContract`.
+An example handler:
+```phpt
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use Nwilging\LaravelSlackBot\Support\SlackCommandRequest;
+use Symfony\Component\HttpFoundation\Response;
+
+class TestCommandHandler implements SlackCommandHandlerContract
+{
+    public function handle(SlackCommandRequest $commandRequest): Response
+    {
+        return response('OK');
+    }
+}
+```
+
+### Registering Command Handlers
+
+Command handlers should be registered in a service provider so that they are available
+once the application boots. You may do this in any service provider that is already
+registered in your application. Place the command handler registrations inside the
+`register` method of your service provider.
+
+```phpt
+<?php
+
+namespace App\Providers;
+
+use App\TestCommandHandler;
+use Illuminate\Support\ServiceProvider;
+use Nwilging\LaravelSlackBot\Contracts\Services\SlackCommandHandlerFactoryServiceContract;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        /** @var SlackCommandHandlerFactoryServiceContract $slackCommandFactory */
+        $slackCommandFactory = $this->app->make(SlackCommandHandlerFactoryServiceContract::class);
+        $slackCommandFactory->register(TestCommandHandler::class, 'command-name');
+    }
+}
+```

--- a/config/slack.php
+++ b/config/slack.php
@@ -5,4 +5,5 @@ return [
     'bot_token' => env('SLACK_API_BOT_TOKEN'),
     'api_url' => env('SLACK_API_URL', 'https://slack.com/api'),
     'driver_name' => env('SLACK_API_DRIVER_NAME', 'slack'),
+    'signing_secret' => env('SLACK_API_SIGNING_SECRET'),
 ];

--- a/src/Contracts/Services/SlackCommandHandlerFactoryServiceContract.php
+++ b/src/Contracts/Services/SlackCommandHandlerFactoryServiceContract.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Contracts\Services;
+
+use Nwilging\LaravelSlackBot\Contracts\SlackCommandHandlerContract;
+
+interface SlackCommandHandlerFactoryServiceContract
+{
+    public function register(string $slackCommandHandlerClass, string $slackSlashCommand): void;
+
+    public function getHandler(string $slackSlashCommand): SlackCommandHandlerContract;
+}

--- a/src/Contracts/Services/SlackCommandHandlerFactoryServiceContract.php
+++ b/src/Contracts/Services/SlackCommandHandlerFactoryServiceContract.php
@@ -7,7 +7,21 @@ use Nwilging\LaravelSlackBot\Contracts\SlackCommandHandlerContract;
 
 interface SlackCommandHandlerFactoryServiceContract
 {
+    /**
+     * Register a command handler class to a given command name
+     *
+     * @param string $slackCommandHandlerClass
+     * @param string $slackSlashCommand
+     * @return void
+     */
     public function register(string $slackCommandHandlerClass, string $slackSlashCommand): void;
 
+    /**
+     * Attempt to retrieve a command handler class. Will throw an exception if the given
+     * command does not have a registered handler.
+     *
+     * @param string $slackSlashCommand
+     * @return SlackCommandHandlerContract
+     */
     public function getHandler(string $slackSlashCommand): SlackCommandHandlerContract;
 }

--- a/src/Contracts/Services/SlackCommandHandlerServiceContract.php
+++ b/src/Contracts/Services/SlackCommandHandlerServiceContract.php
@@ -8,5 +8,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface SlackCommandHandlerServiceContract
 {
+    /**
+     * Handles a Slack Slash Command request. This method should be called from a controller.
+     *
+     * @param Request $request
+     * @return Response
+     */
     public function handle(Request $request): Response;
 }

--- a/src/Contracts/Services/SlackCommandHandlerServiceContract.php
+++ b/src/Contracts/Services/SlackCommandHandlerServiceContract.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Contracts\Services;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface SlackCommandHandlerServiceContract
+{
+    public function handle(Request $request): Response;
+}

--- a/src/Contracts/SlackCommandHandlerContract.php
+++ b/src/Contracts/SlackCommandHandlerContract.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Contracts;
+
+use Nwilging\LaravelSlackBot\Support\SlackCommandRequest;
+use Symfony\Component\HttpFoundation\Response;
+
+interface SlackCommandHandlerContract
+{
+    public function handle(SlackCommandRequest $commandRequest): Response;
+}

--- a/src/Contracts/SlackCommandHandlerContract.php
+++ b/src/Contracts/SlackCommandHandlerContract.php
@@ -8,5 +8,16 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface SlackCommandHandlerContract
 {
+    /**
+     * Handle a slash command request and return an HTTP response to Slack. This method should
+     * return an HTTP request as soon as possible so that Slack does not return a `timeout` response
+     * to the user who issued the command.
+     *
+     * It is highly recommended to dispatch jobs from command handlers for any process that may take longer
+     * than 500-1000 ms.
+     *
+     * @param SlackCommandRequest $commandRequest
+     * @return Response
+     */
     public function handle(SlackCommandRequest $commandRequest): Response;
 }

--- a/src/Providers/SlackBotServiceProvider.php
+++ b/src/Providers/SlackBotServiceProvider.php
@@ -11,9 +11,13 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\ServiceProvider;
 use Nwilging\LaravelSlackBot\Channels\SlackNotificationChannel;
 use Nwilging\LaravelSlackBot\Contracts\Channels\SlackNotificationChannelContract;
+use Nwilging\LaravelSlackBot\Contracts\Services\SlackCommandHandlerFactoryServiceContract;
+use Nwilging\LaravelSlackBot\Contracts\Services\SlackCommandHandlerServiceContract;
 use Nwilging\LaravelSlackBot\Contracts\SlackApiServiceContract;
 use Nwilging\LaravelSlackBot\Contracts\Support\LayoutBuilder\BuilderContract;
 use Nwilging\LaravelSlackBot\Services\SlackApiService;
+use Nwilging\LaravelSlackBot\Services\SlackCommandHandlerFactoryService;
+use Nwilging\LaravelSlackBot\Services\SlackCommandHandlerService;
 use Nwilging\LaravelSlackBot\Support\LayoutBuilder\Builder;
 
 class SlackBotServiceProvider extends ServiceProvider
@@ -46,5 +50,12 @@ class SlackBotServiceProvider extends ServiceProvider
         $this->app->bind(BuilderContract::class, Builder::class);
 
         $this->app->bind(SlackNotificationChannelContract::class, SlackNotificationChannel::class);
+
+        $this->app->singleton(SlackCommandHandlerFactoryServiceContract::class, SlackCommandHandlerFactoryService::class);
+
+        $this->app->bind(SlackCommandHandlerServiceContract::class, SlackCommandHandlerService::class);
+        $this->app->when(SlackCommandHandlerService::class)->needs('$signingSecret')->give(function (): string {
+            return $this->app->make(Config::class)->get('slack.signing_secret');
+        });
     }
 }

--- a/src/Services/SlackCommandHandlerFactoryService.php
+++ b/src/Services/SlackCommandHandlerFactoryService.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Services;
+
+use Illuminate\Contracts\Foundation\Application;
+use Nwilging\LaravelSlackBot\Contracts\Services\SlackCommandHandlerFactoryServiceContract;
+use Nwilging\LaravelSlackBot\Contracts\SlackCommandHandlerContract;
+
+class SlackCommandHandlerFactoryService implements SlackCommandHandlerFactoryServiceContract
+{
+    protected Application $laravel;
+
+    protected array $commandHandlers = [];
+
+    public function __construct(Application $laravel)
+    {
+        $this->laravel = $laravel;
+    }
+
+    public function register(string $slackCommandHandlerClass, string $slackSlashCommand): void
+    {
+        $this->commandHandlers[$slackSlashCommand] = $slackCommandHandlerClass;
+    }
+
+    public function getHandler(string $slackSlashCommand): SlackCommandHandlerContract
+    {
+        if (!array_key_exists($slackSlashCommand, $this->commandHandlers)) {
+            throw new \InvalidArgumentException(sprintf('No handler found for command %s', $slackSlashCommand));
+        }
+
+        return $this->laravel->make($this->commandHandlers[$slackSlashCommand]);
+    }
+}

--- a/src/Services/SlackCommandHandlerService.php
+++ b/src/Services/SlackCommandHandlerService.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Services;
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\UnauthorizedException;
+use Nwilging\LaravelSlackBot\Contracts\Services\SlackCommandHandlerFactoryServiceContract;
+use Nwilging\LaravelSlackBot\Contracts\Services\SlackCommandHandlerServiceContract;
+use Nwilging\LaravelSlackBot\Support\SlackCommandRequest;
+use Symfony\Component\HttpFoundation\Response;
+
+class SlackCommandHandlerService implements SlackCommandHandlerServiceContract
+{
+    protected SlackCommandHandlerFactoryServiceContract $handlerFactory;
+
+    protected string $signingSecret;
+
+    public function __construct(SlackCommandHandlerFactoryServiceContract $handlerFactory, string $signingSecret)
+    {
+        $this->handlerFactory = $handlerFactory;
+        $this->signingSecret = $signingSecret;
+    }
+
+    public function handle(Request $request): Response
+    {
+        $data = ($request->isJson()) ? $request->json()->all() : $request->toArray();
+        $this->validateSignature($request, $data);
+
+        $command = $this->generateCommandRequest($data);
+
+        $handler = $this->handlerFactory->getHandler($command->command);
+        return $handler->handle($command);
+    }
+
+    protected function generateCommandRequest(array $data): SlackCommandRequest
+    {
+        $request = new SlackCommandRequest();
+
+        $request->token = $data['token'];
+        $request->teamId = $data['team_id'];
+        $request->teamDomain = $data['team_domain'];
+        $request->channelId = $data['channel_id'];
+        $request->channelName = $data['channel_name'];
+        $request->userId = $data['user_id'];
+        $request->username = $data['user_name'];
+        $request->command = ltrim($data['command'], '/');
+        $request->commandArgs = explode(' ', $data['text']);
+        $request->apiAppId = $data['api_app_id'];
+        $request->isEnterpriseInstall = ($data['is_enterprise_install'] === 'true');
+        $request->responseUrl = $data['response_url'];
+        $request->triggerId = $data['trigger_id'];
+
+        return $request;
+    }
+
+    protected function validateSignature(Request $request, array $data): void
+    {
+        $timestamp = $request->header('X-Slack-Request-Timestamp');
+        $slackSignature = $request->header('X-Slack-Signature');
+        if (!$timestamp || !$slackSignature) {
+            throw new UnauthorizedException();
+        }
+
+        $formattedRequestBody = implode('&', array_map(function (string $key) use ($data): string {
+            return sprintf('%s=%s', urlencode($key), urlencode($data[$key]));
+        }, array_keys($data)));
+
+        $signatureBase = sprintf('v0:%s:%s', $timestamp, $formattedRequestBody);
+        $signature = sprintf('v0=%s', hash_hmac('sha256', $signatureBase, $this->signingSecret));
+
+        if (!hash_equals($signature, $slackSignature)) {
+            throw new UnauthorizedException();
+        }
+    }
+}

--- a/src/Services/SlackCommandHandlerService.php
+++ b/src/Services/SlackCommandHandlerService.php
@@ -45,7 +45,7 @@ class SlackCommandHandlerService implements SlackCommandHandlerServiceContract
         $request->userId = $data['user_id'];
         $request->username = $data['user_name'];
         $request->command = ltrim($data['command'], '/');
-        $request->commandArgs = explode(' ', $data['text']);
+        $request->commandArgs = explode(' ', $data['text'] ?? '');
         $request->apiAppId = $data['api_app_id'];
         $request->isEnterpriseInstall = ($data['is_enterprise_install'] === 'true');
         $request->responseUrl = $data['response_url'];
@@ -63,7 +63,7 @@ class SlackCommandHandlerService implements SlackCommandHandlerServiceContract
         }
 
         $formattedRequestBody = implode('&', array_map(function (string $key) use ($data): string {
-            return sprintf('%s=%s', urlencode($key), urlencode($data[$key]));
+            return sprintf('%s=%s', urlencode($key), urlencode($data[$key] ?? ''));
         }, array_keys($data)));
 
         $signatureBase = sprintf('v0:%s:%s', $timestamp, $formattedRequestBody);

--- a/src/Support/SlackCommandRequest.php
+++ b/src/Support/SlackCommandRequest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBot\Support;
+
+class SlackCommandRequest
+{
+    /**
+     * @deprecated
+     * Verification token
+     *
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $token;
+
+    /**
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $teamId;
+
+    /**
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $teamDomain;
+
+    /**
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $channelId;
+
+    /**
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $channelName;
+
+    /**
+     * The ID of the user who triggered the command
+     *
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $userId;
+
+    /**
+     * @deprecated https://api.slack.com/interactivity/slash-commands#escaping_users_warning
+     * The plain text name of the user who triggered the command
+     *
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $username;
+
+    /**
+     * The command that was typed in to trigger this request
+     *
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $command;
+
+    /**
+     * Array of command arguments from the `text` parameter of the original Slack request
+     *
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var array
+     */
+    public array $commandArgs;
+
+    /**
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $apiAppId;
+
+    /**
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var bool
+     */
+    public bool $isEnterpriseInstall;
+
+    /**
+     * A temporary webhook URL that you can use to generate messages responses.
+     *
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $responseUrl;
+
+    /**
+     * A short-lived ID that will let your app open a modal.
+     *
+     * @see https://api.slack.com/interactivity/slash-commands#app_command_handling
+     * @var string
+     */
+    public string $triggerId;
+}

--- a/tests/Unit/Services/SlackCommandHandlerFactoryServiceTest.php
+++ b/tests/Unit/Services/SlackCommandHandlerFactoryServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBotTests\Unit\Services;
+
+use Illuminate\Contracts\Foundation\Application;
+use Mockery\MockInterface;
+use Nwilging\LaravelSlackBot\Contracts\SlackCommandHandlerContract;
+use Nwilging\LaravelSlackBot\Services\SlackCommandHandlerFactoryService;
+use Nwilging\LaravelSlackBotTests\TestCase;
+
+class SlackCommandHandlerFactoryServiceTest extends TestCase
+{
+    protected MockInterface $laravel;
+
+    protected SlackCommandHandlerFactoryService $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->laravel = \Mockery::mock(Application::class);
+        $this->service = new SlackCommandHandlerFactoryService($this->laravel);
+    }
+
+    public function testRegisterAndGetHandlerSuccess()
+    {
+        $command = 'test';
+        $handlerClass = 'App\\TestClass';
+
+        $this->service->register($handlerClass, $command);
+
+        $handlerMock = \Mockery::mock(SlackCommandHandlerContract::class);
+        $this->laravel->shouldReceive('make')
+            ->once()
+            ->with($handlerClass)
+            ->andReturn($handlerMock);
+
+        $result = $this->service->getHandler($command);
+        $this->assertSame($result, $handlerMock);
+    }
+
+    public function testRegisterAndGetHandlerFailsForMissingCommandHandler()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No handler found for command invalid-command');
+
+        $this->service->getHandler('invalid-command');
+    }
+}

--- a/tests/Unit/Services/SlackCommandHandlerServiceTest.php
+++ b/tests/Unit/Services/SlackCommandHandlerServiceTest.php
@@ -15,6 +15,12 @@ use Nwilging\LaravelSlackBotTests\TestCase;
 
 class SlackCommandHandlerServiceTest extends TestCase
 {
+    /**
+     * Generated with:
+     * `openssl rand -hex 16`
+     *
+     * Not a real slack signing key.
+     */
     protected string $testSigningKey = '11f1ae1af09ccb257214ba904873c789';
 
     protected MockInterface $slackCommandHandlerFactory;
@@ -55,6 +61,12 @@ class SlackCommandHandlerServiceTest extends TestCase
 
     public function testHandleThrowsExceptionWhenSignaturesDoNotMatch()
     {
+        /**
+         * Generated with:
+         * `openssl rand -hex 16`
+         *
+         * Not a real slack signing key.
+         */
         $invalidSigningKey = 'd23375f4085b76a94f6df746fbcd62ef';
         $requestData = [
             'key' => 'value',

--- a/tests/Unit/Services/SlackCommandHandlerServiceTest.php
+++ b/tests/Unit/Services/SlackCommandHandlerServiceTest.php
@@ -1,0 +1,218 @@
+<?php
+declare(strict_types=1);
+
+namespace Nwilging\LaravelSlackBotTests\Unit\Services;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\UnauthorizedException;
+use Mockery\MockInterface;
+use Nwilging\LaravelSlackBot\Contracts\Services\SlackCommandHandlerFactoryServiceContract;
+use Nwilging\LaravelSlackBot\Contracts\SlackCommandHandlerContract;
+use Nwilging\LaravelSlackBot\Services\SlackCommandHandlerService;
+use Nwilging\LaravelSlackBot\Support\SlackCommandRequest;
+use Nwilging\LaravelSlackBotTests\TestCase;
+
+class SlackCommandHandlerServiceTest extends TestCase
+{
+    protected string $testSigningKey = '11f1ae1af09ccb257214ba904873c789';
+
+    protected MockInterface $slackCommandHandlerFactory;
+
+    protected SlackCommandHandlerService $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->slackCommandHandlerFactory = \Mockery::mock(SlackCommandHandlerFactoryServiceContract::class);
+        $this->service = new SlackCommandHandlerService($this->slackCommandHandlerFactory, $this->testSigningKey);
+    }
+
+    public function testHandleThrowsExceptionWhenRequiredHeaderTimestampMissing()
+    {
+        $request = \Mockery::mock(Request::class);
+        $request->shouldReceive('header')->with('X-Slack-Request-Timestamp')->andReturnNull();
+        $request->shouldReceive('header')->with('X-Slack-Signature')->andReturnNull();
+        $request->shouldReceive('isJson')->andReturnFalse();
+        $request->shouldReceive('toArray')->andReturn([]);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->service->handle($request);
+    }
+
+    public function testHandleThrowsExceptionWhenRequiredHeaderSignatureMissing()
+    {
+        $request = \Mockery::mock(Request::class);
+        $request->shouldReceive('header')->with('X-Slack-Request-Timestamp')->andReturn('12345');
+        $request->shouldReceive('header')->with('X-Slack-Signature')->andReturnNull();
+        $request->shouldReceive('isJson')->andReturnFalse();
+        $request->shouldReceive('toArray')->andReturn([]);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->service->handle($request);
+    }
+
+    public function testHandleThrowsExceptionWhenSignaturesDoNotMatch()
+    {
+        $invalidSigningKey = 'd23375f4085b76a94f6df746fbcd62ef';
+        $requestData = [
+            'key' => 'value',
+            'key2' => 'val2',
+        ];
+
+        $formattedRequestBody = implode('&', array_map(function (string $key) use ($requestData): string {
+            return sprintf('%s=%s', urlencode($key), urlencode($requestData[$key] ?? ''));
+        }, array_keys($requestData)));
+
+        $headerTimestamp = '12345';
+
+        $headerSignatureBase = sprintf('v0:%s:%s', $headerTimestamp, $formattedRequestBody);
+        $headerSignature = sprintf('v0=%s', hash_hmac('sha256', $headerSignatureBase, $invalidSigningKey));
+
+        $request = \Mockery::mock(Request::class);
+        $request->shouldReceive('header')->with('X-Slack-Request-Timestamp')->andReturn($headerTimestamp);
+        $request->shouldReceive('header')->with('X-Slack-Signature')->andReturn($headerSignature);
+        $request->shouldReceive('isJson')->andReturnFalse();
+        $request->shouldReceive('toArray')->andReturn($requestData);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->service->handle($request);
+    }
+
+    public function testHandleSuccess()
+    {
+        $requestData = [
+            'token' => 'test-token',
+            'team_id' => 'test-team-id',
+            'team_domain' => 'test-team-domain',
+            'channel_id' => 'test-channel-id',
+            'channel_name' => 'test-channel-name',
+            'user_id' => 'test-user-id',
+            'user_name' => 'test-user-name',
+            'command' => '/test-command',
+            'text' => 'arg1 arg2 arg3',
+            'api_app_id' => 'test-api-app-id',
+            'is_enterprise_install' => 'true',
+            'response_url' => 'test-response-url',
+            'trigger_id' => 'test-trigger-id',
+        ];
+
+        $formattedRequestBody = implode('&', array_map(function (string $key) use ($requestData): string {
+            return sprintf('%s=%s', urlencode($key), urlencode($requestData[$key] ?? ''));
+        }, array_keys($requestData)));
+
+        $headerTimestamp = '12345';
+
+        $headerSignatureBase = sprintf('v0:%s:%s', $headerTimestamp, $formattedRequestBody);
+        $headerSignature = sprintf('v0=%s', hash_hmac('sha256', $headerSignatureBase, $this->testSigningKey));
+
+        $request = \Mockery::mock(Request::class);
+        $request->shouldReceive('header')->with('X-Slack-Request-Timestamp')->andReturn($headerTimestamp);
+        $request->shouldReceive('header')->with('X-Slack-Signature')->andReturn($headerSignature);
+        $request->shouldReceive('isJson')->andReturnTrue();
+        $request->shouldReceive('json')->andReturnSelf();
+
+        $request->shouldAllowMockingMethod('all');
+        $request->shouldReceive('all')->andReturn($requestData);
+
+        $responseMock = \Mockery::mock(Response::class);
+
+        $handlerMock = \Mockery::mock(SlackCommandHandlerContract::class);
+        $handlerMock->shouldReceive('handle')
+            ->once()
+            ->with(\Mockery::on(function (SlackCommandRequest $slackRequest) use ($requestData): bool {
+                $this->assertSame($slackRequest->token, $requestData['token']);
+                $this->assertSame($slackRequest->teamId, $requestData['team_id']);
+                $this->assertSame($slackRequest->teamDomain, $requestData['team_domain']);
+                $this->assertSame($slackRequest->channelId, $requestData['channel_id']);
+                $this->assertSame($slackRequest->channelName, $requestData['channel_name']);
+                $this->assertSame($slackRequest->userId, $requestData['user_id']);
+                $this->assertSame($slackRequest->username, $requestData['user_name']);
+                $this->assertSame($slackRequest->command, 'test-command');
+                $this->assertSame($slackRequest->commandArgs, ['arg1', 'arg2', 'arg3']);
+                $this->assertSame($slackRequest->apiAppId, $requestData['api_app_id']);
+                $this->assertSame($slackRequest->isEnterpriseInstall, true);
+                $this->assertSame($slackRequest->responseUrl, $requestData['response_url']);
+                $this->assertSame($slackRequest->triggerId, $requestData['trigger_id']);
+
+                return true;
+            }))->andReturn($responseMock);
+
+        $this->slackCommandHandlerFactory->shouldReceive('getHandler')
+            ->once()
+            ->with('test-command')
+            ->andReturn($handlerMock);
+
+        $result = $this->service->handle($request);
+        $this->assertSame($responseMock, $result);
+    }
+
+    public function testHandleSuccessWithEmptyArgs()
+    {
+        $requestData = [
+            'token' => 'test-token',
+            'team_id' => 'test-team-id',
+            'team_domain' => 'test-team-domain',
+            'channel_id' => 'test-channel-id',
+            'channel_name' => 'test-channel-name',
+            'user_id' => 'test-user-id',
+            'user_name' => 'test-user-name',
+            'command' => '/test-command',
+            'text' => null,
+            'api_app_id' => 'test-api-app-id',
+            'is_enterprise_install' => 'true',
+            'response_url' => 'test-response-url',
+            'trigger_id' => 'test-trigger-id',
+        ];
+
+        $formattedRequestBody = implode('&', array_map(function (string $key) use ($requestData): string {
+            return sprintf('%s=%s', urlencode($key), urlencode($requestData[$key] ?? ''));
+        }, array_keys($requestData)));
+
+        $headerTimestamp = '12345';
+
+        $headerSignatureBase = sprintf('v0:%s:%s', $headerTimestamp, $formattedRequestBody);
+        $headerSignature = sprintf('v0=%s', hash_hmac('sha256', $headerSignatureBase, $this->testSigningKey));
+
+        $request = \Mockery::mock(Request::class);
+        $request->shouldReceive('header')->with('X-Slack-Request-Timestamp')->andReturn($headerTimestamp);
+        $request->shouldReceive('header')->with('X-Slack-Signature')->andReturn($headerSignature);
+        $request->shouldReceive('isJson')->andReturnTrue();
+        $request->shouldReceive('json')->andReturnSelf();
+
+        $request->shouldAllowMockingMethod('all');
+        $request->shouldReceive('all')->andReturn($requestData);
+
+        $responseMock = \Mockery::mock(Response::class);
+
+        $handlerMock = \Mockery::mock(SlackCommandHandlerContract::class);
+        $handlerMock->shouldReceive('handle')
+            ->once()
+            ->with(\Mockery::on(function (SlackCommandRequest $slackRequest) use ($requestData): bool {
+                $this->assertSame($slackRequest->token, $requestData['token']);
+                $this->assertSame($slackRequest->teamId, $requestData['team_id']);
+                $this->assertSame($slackRequest->teamDomain, $requestData['team_domain']);
+                $this->assertSame($slackRequest->channelId, $requestData['channel_id']);
+                $this->assertSame($slackRequest->channelName, $requestData['channel_name']);
+                $this->assertSame($slackRequest->userId, $requestData['user_id']);
+                $this->assertSame($slackRequest->username, $requestData['user_name']);
+                $this->assertSame($slackRequest->command, 'test-command');
+                $this->assertSame($slackRequest->commandArgs, ['']);
+                $this->assertSame($slackRequest->apiAppId, $requestData['api_app_id']);
+                $this->assertSame($slackRequest->isEnterpriseInstall, true);
+                $this->assertSame($slackRequest->responseUrl, $requestData['response_url']);
+                $this->assertSame($slackRequest->triggerId, $requestData['trigger_id']);
+
+                return true;
+            }))->andReturn($responseMock);
+
+        $this->slackCommandHandlerFactory->shouldReceive('getHandler')
+            ->once()
+            ->with('test-command')
+            ->andReturn($handlerMock);
+
+        $result = $this->service->handle($request);
+        $this->assertSame($responseMock, $result);
+    }
+}


### PR DESCRIPTION
Adds support for handling slash command HTTP requests. Includes a service to handle these events in end-user projects as well as a factory service to register command handlers.

### To-Do:

- [x] Update readme
- [x] Add additional method docblocks for new services