### PR TITLE
Handle false unfurl flags correctly

### DIFF
--- a/src/Services/SlackApiService.php
+++ b/src/Services/SlackApiService.php
@@ -142,8 +142,8 @@ class SlackApiService implements SlackApiServiceContract
         if (!empty($options['unfurl'])) {
             $unfurlOptions = $options['unfurl'];
 
-            if (array_key_exists('media', $unfurlOptions)) $payload['unfurl_media'] = $unfurlOptions['media'];
-            if (array_key_exists('links', $unfurlOptions)) $payload['unfurl_links'] = $unfurlOptions['links'];
+            if (isset($unfurlOptions['media'])) $payload['unfurl_media'] = $unfurlOptions['media'];
+            if (isset($unfurlOptions['links'])) $payload['unfurl_links'] = $unfurlOptions['links'];
         }
 
         if (!empty($options['thread'])) {

--- a/src/Services/SlackApiService.php
+++ b/src/Services/SlackApiService.php
@@ -142,8 +142,8 @@ class SlackApiService implements SlackApiServiceContract
         if (!empty($options['unfurl'])) {
             $unfurlOptions = $options['unfurl'];
 
-            if (!empty($unfurlOptions['media'])) $payload['unfurl_media'] = $unfurlOptions['media'];
-            if (!empty($unfurlOptions['links'])) $payload['unfurl_links'] = $unfurlOptions['links'];
+            if (array_key_exists('media', $unfurlOptions)) $payload['unfurl_media'] = $unfurlOptions['media'];
+            if (array_key_exists('links', $unfurlOptions)) $payload['unfurl_links'] = $unfurlOptions['links'];
         }
 
         if (!empty($options['thread'])) {

--- a/tests/Unit/Services/SlackApiServiceTest.php
+++ b/tests/Unit/Services/SlackApiServiceTest.php
@@ -369,7 +369,7 @@ class SlackApiServiceTest extends TestCase
                     ],
                     'unfurl' => [
                         'media' => true,
-                        'links' => true,
+                        'links' => false,
                     ],
                     'thread' => [
                         'ts' => 'test',
@@ -383,7 +383,7 @@ class SlackApiServiceTest extends TestCase
                     'username' => 'Test User',
                     'icon_url' => 'https://example.com',
                     'unfurl_media' => true,
-                    'unfurl_links' => true,
+                    'unfurl_links' => false,
                     'thread_ts' => 'test',
                     'reply_broadcast' => true,
                     'mrkdwn' => true,


### PR DESCRIPTION
```
$unfurlOptions['links'] = false;
empty($unfurlOptions['links']) === true;
```
The issue is that if links are set to false(to unfurl) they never get sent to the API.
I've changed to test to illustrate the issue. 

this describes the issue further https://stackoverflow.com/questions/1219542/in-where-shall-i-use-isset-and-empty

_"On the other hand the empty() function checks if the variable has an empty value empty string, 0, NULL or False. Returns FALSE if var has a non-empty and non-zero value."_